### PR TITLE
Gradle関係の改善

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,8 +22,8 @@ idea {
     }
 }
 
-task wrapper(type: Wrapper) {
-    gradleVersion = '4.8.1'
+tasks.getByName("wrapper") {
+    gradleVersion = '6.2'
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -36,29 +36,29 @@ allprojects {
 dependencies {
 
     // Translation Exclusion Library
-    implementation('com.google.code.findbugs:jsr305:3.0.2')
+    implementation(Dependencies.JSR_305)
 
     // Common Library
-    implementation('org.apache.commons:commons-lang3:3.7')
-    implementation('commons-codec:commons-codec:1.11')
-    implementation('com.google.code.gson:gson:2.8.2')
-    implementation('org.scribe:scribe:1.3.3')
+    implementation(Dependencies.COMMONS_LANG)
+    implementation(Dependencies.COMMONS_CODEC)
+    implementation(Dependencies.GSON)
+    implementation(Dependencies.SCRIBE)
 
     // J2ObjC Common Library
-    implementation('com.github.uakihir0:JLogger:1.1')
-    implementation('com.github.uakihir0:JHttpClient:1.1.5')
+    implementation(Dependencies.JLOGGER)
+    implementation(Dependencies.JHTTP_CLIENT)
 
     // J2ObjC Network Library
-    api('com.github.uakihir0.twitter4j:twitter4j-core:4.0.8.4')
-    api('com.github.uakihir0.twitter4j:twitter4j-stream:4.0.8.4')
-    api('com.github.uakihir0:twitter-text:3.0.1.1')
-    api('com.github.uakihir0.facebook4j:facebook4j-core:2.4.11.3')
-    api('com.github.uakihir0.jslack:jslack-api-client:3.2.2.2')
-    api('com.github.uakihir0.jslack:jslack-api-model:3.2.2.2')
-    api('com.github.uakihir0:msinstance4j:0.0.3')
-    api('com.github.uakihir0:mastodon4j:0.2.32')
-    api('com.github.uakihir0:jumblr:0.0.13.10')
+    api(Dependencies.TWITTER4J_CORE)
+    api(Dependencies.TWITTER4J_STREAM)
+    api(Dependencies.TWITTER_TEXT)
+    api(Dependencies.FACEBOOK4J)
+    api(Dependencies.JSLACK_CLIENT)
+    api(Dependencies.JSLACK_MODEL)
+    api(Dependencies.MSINSTANCEJ)
+    api(Dependencies.MASTODON4J)
+    api(Dependencies.JUMBLR)
 
     // Test
-    testImplementation('junit:junit:4.12')
+    testImplementation(Dependencies.JUNIT)
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 }
 
 plugins {
-    id 'java'
+    id 'java-library'
     id 'idea'
     id 'maven'
 }
@@ -39,26 +39,26 @@ dependencies {
     implementation('com.google.code.findbugs:jsr305:3.0.2')
 
     // Common Library
-    compile('org.apache.commons:commons-lang3:3.7')
-    compile('commons-codec:commons-codec:1.11')
-    compile('com.google.code.gson:gson:2.8.2')
-    compile('org.scribe:scribe:1.3.3')
+    implementation('org.apache.commons:commons-lang3:3.7')
+    implementation('commons-codec:commons-codec:1.11')
+    implementation('com.google.code.gson:gson:2.8.2')
+    implementation('org.scribe:scribe:1.3.3')
 
     // J2ObjC Common Library
-    compile('com.github.uakihir0:JLogger:1.1')
-    compile('com.github.uakihir0:JHttpClient:1.1.5')
+    implementation('com.github.uakihir0:JLogger:1.1')
+    implementation('com.github.uakihir0:JHttpClient:1.1.5')
 
     // J2ObjC Network Library
-    compile('com.github.uakihir0.twitter4j:twitter4j-core:4.0.8.4')
-    compile('com.github.uakihir0.twitter4j:twitter4j-stream:4.0.8.4')
-    compile('com.github.uakihir0:twitter-text:3.0.1.1')
-    compile('com.github.uakihir0.facebook4j:facebook4j-core:2.4.11.3')
-    compile('com.github.uakihir0.jslack:jslack-api-client:3.2.2.2')
-    compile('com.github.uakihir0.jslack:jslack-api-model:3.2.2.2')
-    compile('com.github.uakihir0:msinstance4j:0.0.3')
-    compile('com.github.uakihir0:mastodon4j:0.2.32')
-    compile('com.github.uakihir0:jumblr:0.0.13.10')
+    api('com.github.uakihir0.twitter4j:twitter4j-core:4.0.8.4')
+    api('com.github.uakihir0.twitter4j:twitter4j-stream:4.0.8.4')
+    api('com.github.uakihir0:twitter-text:3.0.1.1')
+    api('com.github.uakihir0.facebook4j:facebook4j-core:2.4.11.3')
+    api('com.github.uakihir0.jslack:jslack-api-client:3.2.2.2')
+    api('com.github.uakihir0.jslack:jslack-api-model:3.2.2.2')
+    api('com.github.uakihir0:msinstance4j:0.0.3')
+    api('com.github.uakihir0:mastodon4j:0.2.32')
+    api('com.github.uakihir0:jumblr:0.0.13.10')
 
     // Test
-    testCompile('junit:junit:4.12')
+    testImplementation('junit:junit:4.12')
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,23 @@
+plugins {
+    `embedded-kotlin`
+}
+
+group = "SocialHub"
+version = "1.0-SNAPSHOT"
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation(kotlin("stdlib-jdk8"))
+}
+
+tasks {
+    compileKotlin {
+        kotlinOptions.jvmTarget = "1.8"
+    }
+    compileTestKotlin {
+        kotlinOptions.jvmTarget = "1.8"
+    }
+}

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,0 +1,22 @@
+object Dependencies {
+    const val JSR_305 = "com.google.code.findbugs:jsr305:3.0.2"
+    const val COMMONS_LANG = "org.apache.commons:commons-lang3:3.7"
+    const val COMMONS_CODEC = "commons-codec:commons-codec:1.11"
+    const val GSON = "com.google.code.gson:gson:2.8.2"
+    const val SCRIBE = "org.scribe:scribe:1.3.3"
+
+    const val JLOGGER = "com.github.uakihir0:JLogger:1.1"
+    const val JHTTP_CLIENT = "com.github.uakihir0:JHttpClient:1.1.5"
+
+    const val TWITTER4J_CORE = "com.github.uakihir0.twitter4j:twitter4j-core:4.0.8.4"
+    const val TWITTER4J_STREAM = "com.github.uakihir0.twitter4j:twitter4j-stream:4.0.8.4"
+    const val TWITTER_TEXT = "com.github.uakihir0:twitter-text:3.0.1.1"
+    const val FACEBOOK4J = "com.github.uakihir0.facebook4j:facebook4j-core:2.4.11.3"
+    const val JSLACK_CLIENT = "com.github.uakihir0.jslack:jslack-api-client:3.2.2.2"
+    const val JSLACK_MODEL = "com.github.uakihir0.jslack:jslack-api-model:3.2.2.2"
+    const val MSINSTANCEJ = "com.github.uakihir0:msinstance4j:0.0.3"
+    const val MASTODON4J = "com.github.uakihir0:mastodon4j:0.2.32"
+    const val JUMBLR = "com.github.uakihir0:jumblr:0.0.13.10"
+
+    const val JUNIT = "junit:junit:4.12"
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.8.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/j2objc.gradle
+++ b/j2objc.gradle
@@ -5,7 +5,7 @@ buildscript {
 }
 
 plugins {
-    id 'java'
+    id 'java-library'
     id 'idea'
     id 'maven'
     id 'net.socialhub.j2objccontrib.j2objcgradle' version '0.7.1'
@@ -42,28 +42,28 @@ dependencies {
     implementation('com.google.code.findbugs:jsr305:3.0.2')
 
     // Common Library
-    compile('org.apache.commons:commons-lang3:3.7')
-    compile('commons-codec:commons-codec:1.11')
-    compile('com.google.code.gson:gson:2.8.2')
-    compile('org.scribe:scribe:1.3.3')
+    implementation('org.apache.commons:commons-lang3:3.7')
+    implementation('commons-codec:commons-codec:1.11')
+    implementation('com.google.code.gson:gson:2.8.2')
+    implementation('org.scribe:scribe:1.3.3')
 
     // J2ObjC Common Library
-    compile('com.github.uakihir0:JLogger:1.1')
-    compile('com.github.uakihir0:JHttpClient:1.1.5')
+    implementation('com.github.uakihir0:JLogger:1.1')
+    implementation('com.github.uakihir0:JHttpClient:1.1.5')
 
     // J2ObjC Network Library
-    compile('com.github.uakihir0.twitter4j:twitter4j-core:4.0.8.4')
-    compile('com.github.uakihir0.twitter4j:twitter4j-stream:4.0.8.4')
-    compile('com.github.uakihir0:twitter-text:3.0.1.1')
-    compile('com.github.uakihir0.facebook4j:facebook4j-core:2.4.11.3')
-    compile('com.github.uakihir0.jslack:jslack-api-client:3.2.2.2')
-    compile('com.github.uakihir0.jslack:jslack-api-model:3.2.2.2')
-    compile('com.github.uakihir0:msinstance4j:0.0.3')
-    compile('com.github.uakihir0:mastodon4j:0.2.32')
-    compile('com.github.uakihir0:jumblr:0.0.13.10')
+    api('com.github.uakihir0.twitter4j:twitter4j-core:4.0.8.4')
+    api('com.github.uakihir0.twitter4j:twitter4j-stream:4.0.8.4')
+    api('com.github.uakihir0:twitter-text:3.0.1.1')
+    api('com.github.uakihir0.facebook4j:facebook4j-core:2.4.11.3')
+    api('com.github.uakihir0.jslack:jslack-api-client:3.2.2.2')
+    api('com.github.uakihir0.jslack:jslack-api-model:3.2.2.2')
+    api('com.github.uakihir0:msinstance4j:0.0.3')
+    api('com.github.uakihir0:mastodon4j:0.2.32')
+    api('com.github.uakihir0:jumblr:0.0.13.10')
 
     // Test
-    testCompile('junit:junit:4.12')
+    testImplementation('junit:junit:4.12')
 }
 
 

--- a/j2objc.gradle
+++ b/j2objc.gradle
@@ -39,31 +39,31 @@ allprojects {
 dependencies {
 
     // Translation Exclusion Library
-    implementation('com.google.code.findbugs:jsr305:3.0.2')
+    implementation(Dependencies.JSR_305)
 
     // Common Library
-    implementation('org.apache.commons:commons-lang3:3.7')
-    implementation('commons-codec:commons-codec:1.11')
-    implementation('com.google.code.gson:gson:2.8.2')
-    implementation('org.scribe:scribe:1.3.3')
+    implementation(Dependencies.COMMONS_LANG)
+    implementation(Dependencies.COMMONS_CODEC)
+    implementation(Dependencies.GSON)
+    implementation(Dependencies.SCRIBE)
 
     // J2ObjC Common Library
-    implementation('com.github.uakihir0:JLogger:1.1')
-    implementation('com.github.uakihir0:JHttpClient:1.1.5')
+    implementation(Dependencies.JLOGGER)
+    implementation(Dependencies.JHTTP_CLIENT)
 
     // J2ObjC Network Library
-    api('com.github.uakihir0.twitter4j:twitter4j-core:4.0.8.4')
-    api('com.github.uakihir0.twitter4j:twitter4j-stream:4.0.8.4')
-    api('com.github.uakihir0:twitter-text:3.0.1.1')
-    api('com.github.uakihir0.facebook4j:facebook4j-core:2.4.11.3')
-    api('com.github.uakihir0.jslack:jslack-api-client:3.2.2.2')
-    api('com.github.uakihir0.jslack:jslack-api-model:3.2.2.2')
-    api('com.github.uakihir0:msinstance4j:0.0.3')
-    api('com.github.uakihir0:mastodon4j:0.2.32')
-    api('com.github.uakihir0:jumblr:0.0.13.10')
+    api(Dependencies.TWITTER4J_CORE)
+    api(Dependencies.TWITTER4J_STREAM)
+    api(Dependencies.TWITTER_TEXT)
+    api(Dependencies.FACEBOOK4J)
+    api(Dependencies.JSLACK_CLIENT)
+    api(Dependencies.JSLACK_MODEL)
+    api(Dependencies.MSINSTANCEJ)
+    api(Dependencies.MASTODON4J)
+    api(Dependencies.JUMBLR)
 
     // Test
-    testImplementation('junit:junit:4.12')
+    testImplementation(Dependencies.JUNIT)
 }
 
 

--- a/j2objc.gradle
+++ b/j2objc.gradle
@@ -39,28 +39,28 @@ allprojects {
 dependencies {
 
     // Translation Exclusion Library
-    implementation(Dependencies.JSR_305)
+    compile(Dependencies.JSR_305)
 
     // Common Library
-    implementation(Dependencies.COMMONS_LANG)
-    implementation(Dependencies.COMMONS_CODEC)
-    implementation(Dependencies.GSON)
-    implementation(Dependencies.SCRIBE)
+    compile(Dependencies.COMMONS_LANG)
+    compile(Dependencies.COMMONS_CODEC)
+    compile(Dependencies.GSON)
+    compile(Dependencies.SCRIBE)
 
     // J2ObjC Common Library
-    implementation(Dependencies.JLOGGER)
-    implementation(Dependencies.JHTTP_CLIENT)
+    compile(Dependencies.JLOGGER)
+    compile(Dependencies.JHTTP_CLIENT)
 
     // J2ObjC Network Library
-    api(Dependencies.TWITTER4J_CORE)
-    api(Dependencies.TWITTER4J_STREAM)
-    api(Dependencies.TWITTER_TEXT)
-    api(Dependencies.FACEBOOK4J)
-    api(Dependencies.JSLACK_CLIENT)
-    api(Dependencies.JSLACK_MODEL)
-    api(Dependencies.MSINSTANCEJ)
-    api(Dependencies.MASTODON4J)
-    api(Dependencies.JUMBLR)
+    compile(Dependencies.TWITTER4J_CORE)
+    compile(Dependencies.TWITTER4J_STREAM)
+    compile(Dependencies.TWITTER_TEXT)
+    compile(Dependencies.FACEBOOK4J)
+    compile(Dependencies.JSLACK_CLIENT)
+    compile(Dependencies.JSLACK_MODEL)
+    compile(Dependencies.MSINSTANCEJ)
+    compile(Dependencies.MASTODON4J)
+    compile(Dependencies.JUMBLR)
 
     // Test
     testImplementation(Dependencies.JUNIT)


### PR DESCRIPTION
本体に影響のない範囲でGradle周りの改善を行いました。変更点は以下のとおりです。


- Gradleのバージョンを6.2に
- javaプラグインをjava-libraryプラグインに変更
- 依存関係の`compile`を用いた依存関係の設定は非推奨であるため、`implementation`と`api`に変更
- 2つのgradleファイルで依存関係の内容が同じであったため、`buildSrc`に抽出